### PR TITLE
Optimize Dockerfile with cached layers for package installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,10 @@ WORKDIR /usr/src/app
 # Install app dependencies
 RUN apk update && apk upgrade && apk add --no-cache git
 
-COPY . /usr/src/app/
+COPY package.json /usr/src/app/package.json
 RUN npm install --no-optional
+
+COPY . /usr/src/app/
 RUN npm run build
 
 ENV HOST 0.0.0.0

--- a/vue.config.js
+++ b/vue.config.js
@@ -15,10 +15,8 @@
  */
 
 module.exports = {
+    publicPath: '/tradr/',
     configureWebpack: {
-        output: {
-            publicPath: '/tradr/'
-        },
         resolve: {
             modules: [
                 'src/assets'


### PR DESCRIPTION
Separate the `npm install` from `npm build` to utilize a cached install layer for much faster building.

Reduces subsequent build time by at least 90% when package.json does not change.
Also reduces size of images pushed with `docker push` by 97%, and speeds up pulling for updating the image.